### PR TITLE
Only add Convolve transformation if there are hrf_variables, fix user pred search

### DIFF
--- a/pyns/models/analysis.py
+++ b/pyns/models/analysis.py
@@ -215,8 +215,10 @@ class Analyses(Base):
             set([p['name'] for p in public_preds])
         if private_preds:
             # Get Predictor IDs
-            predictors += [p['id'] for p in self._client.user.get_predictors(
-                run_id=run_id, name=private_preds)]
+            for pred in private_preds:
+                predictors += [p['id']
+                               for p in self._client.user.get_predictors(
+                                   run_id=run_id, name=pred)]
 
         if len(predictors) != len(predictor_names):
             raise ValueError(

--- a/pyns/models/utils.py
+++ b/pyns/models/utils.py
@@ -27,10 +27,11 @@ def build_model(name, variables, task, subject, run=None, session=None,
     if not set(variables) >= set(hrf_variables):
         raise ValueError("HRF Variables must be a subset of all variables")
 
-    transformations.append({
-        "Input": hrf_variables,
-        "Name": "Convolve"
-    })
+    if hrf_variables:
+        transformations.append({
+            "Input": hrf_variables,
+            "Name": "Convolve"
+        })
 
     model = {
         "Steps": [


### PR DESCRIPTION
Two fixes to the `create_analysis` function:
- Only add a `Convolve` transformation is any `hrf_variables` are specificied
- Fix user predictor search. Need to loop over missing variables being searched for API to return correct response (not sure why should fix on API side at some point).