### PR TITLE
Load and plot uploads

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install nilearn nibabel
         python -m pip install -r requirements.txt
         python -m pip install pytest-cov
     - name: Test with pytest

--- a/pyns/models/analysis.py
+++ b/pyns/models/analysis.py
@@ -398,12 +398,13 @@ class Analyses(Base):
         if download_dir is None:
             download_dir = TMP_DIR
 
+        # Sort uploads for upload date
         uploads = self.get_uploads(id)
         for u in uploads:
             u['uploaded_at'] = datetime.datetime.strptime(u['uploaded_at'], '%Y-%m-%dT%H:%M')
         uploads = sorted(uploads, key=lambda x: x['uploaded_at'], reverse=(select=='latest'))
 
-        # Select based on collection filters
+        # Select collections based on filters
         uploads = [
             u for u in uploads 
             if all([u.get(k, None) == v for k, v in coll_filt.items()])
@@ -412,7 +413,7 @@ class Analyses(Base):
         if select is not None:
             uploads = [uploads[0]]
 
-        # Select based on coll_filt
+        # Select files based on stat_filt, download if necessary and load as Niimg-object
         flat = []
         for u in uploads:
             for f in tqdm.tqdm(u.pop('files')):

--- a/pyns/models/analysis.py
+++ b/pyns/models/analysis.py
@@ -11,6 +11,7 @@ import time
 
 altair = attempt_to_import('altair')
 nib = attempt_to_import('nibabel')
+nilearn = attempt_to_import('nilearn')
 
 
 TMP_DIR = Path(tempfile.mkdtemp())
@@ -24,7 +25,7 @@ class Analysis:
 
     _aliased_methods_ = ['delete', 'get_bundle', 'compile', 'generate_report',
                          'get_report', 'upload_neurovault', 'get_uploads',
-                         'load_uploads',
+                         'load_uploads', 'plot_uploads',
                          'plot_report', 'get_design_matrix']
 
     def __init__(self, *, analyses, name, dataset_id, **kwargs):
@@ -431,8 +432,24 @@ class Analyses(Base):
                         niimg = nib.load(f_name)
                         f.pop('traceback')
                         flat.append((niimg, {**u, **f}))
-
         return flat
+
+
+    def plot_uploads(self, id, plot_args={}, **kwargs):
+        """ Plot uploads for matching collections using nilearn
+        :param str id: Analysis hash_id.
+        
+        :param dict kwargs: Arguments for load_uploads
+        :return list list of matplotlib objects.
+        """
+
+        images = self.load_uploads(id, **kwargs)
+
+        plots = []
+        for niimg, entities in images:
+            plots.append(nilearn.plotting.plot_stat_map(niimg, **plot_args))
+
+        return plots
 
     def get_full(self, id):
         """ Get full analysis object (including runs and predictors)

--- a/pyns/models/analysis.py
+++ b/pyns/models/analysis.py
@@ -456,7 +456,7 @@ class Analyses(Base):
                         f"{u['collection_id']}_{f['basename']}"
 
                     if not f_name.exists():
-                        print("Downloading image...")
+                        print(".", end ="")  
                         with f_name.open('wb') as file:
                             file.write(requests.get(img_url).content)
                     niimg = nib.load(f_name)

--- a/pyns/models/analysis.py
+++ b/pyns/models/analysis.py
@@ -2,12 +2,18 @@
 from .base import Base
 from pathlib import Path
 from functools import partial
+import datetime
+import tempfile
+import requests
 from .utils import build_model, attempt_to_import
 import tqdm
 import time
 
 altair = attempt_to_import('altair')
+nib = attempt_to_import('nibabel')
 
+
+TMP_DIR = Path(tempfile.mkdtemp())
 
 class Analysis:
     """ Analysis object class. Object representing an analysis that can be
@@ -18,6 +24,7 @@ class Analysis:
 
     _aliased_methods_ = ['delete', 'get_bundle', 'compile', 'generate_report',
                          'get_report', 'upload_neurovault', 'get_uploads',
+                         'load_uploads',
                          'plot_report', 'get_design_matrix']
 
     def __init__(self, *, analyses, name, dataset_id, **kwargs):
@@ -377,6 +384,54 @@ class Analyses(Base):
         :return: client response object
         """
         return self.get(id=id, sub_route='upload')
+
+    def load_uploads(self, id, select='latest', coll_filt={}, download_dir=None, **stat_filt):
+        """ Load collection upload as NiBabel images and associated meta-data
+        :param str id: Analysis hash_id.
+        :param str select: How to select if multiple collections ('latest' or 'oldest')
+        :param dict coll_filt: Filter arguments for collections
+        :param str download_dir: Directory to download images. If None, create tempdir
+        :param dict stat_filt: Filter arguments for statmaps, such as BIDS entities
+        :return list list of tuples of format (Nifti1Image, kwargs). 
+        """
+
+        if download_dir is None:
+            download_dir = TMP_DIR
+
+        uploads = self.get_uploads(id)
+        for u in uploads:
+            u['uploaded_at'] = datetime.datetime.strptime(u['uploaded_at'], '%Y-%m-%dT%H:%M')
+        uploads = sorted(uploads, key=lambda x: x['uploaded_at'], reverse=(select=='latest'))
+
+        # Select based on collection filters
+        uploads = [
+            u for u in uploads 
+            if all([u.get(k, None) == v for k, v in coll_filt.items()])
+            ] 
+
+        if select is not None:
+            uploads = [uploads[0]]
+
+        # Select based on coll_filt
+        flat = []
+        for u in uploads:
+            for f in tqdm.tqdm(u.pop('files')):
+                # Filter files
+                if f.pop('status') == 'OK':
+                    if all([f.get(k, None) == v for k, v in stat_filt.items()]):
+
+                        # Download and open
+                        img_url = f"https://neurovault.org/media/images/{u['collection_id']}/{f['basename']}"
+                        f_name = download_dir / f"{u['collection_id']}_{f['basename']}"
+
+                        if not f_name.exists():
+                            with f_name.open('wb') as file:
+                                file.write(requests.get(img_url).content)
+                        niimg = nib.load(f_name)
+                        f.pop('traceback')
+                        flat.append((niimg, {**u, **f}))
+
+        return flat
 
     def get_full(self, id):
         """ Get full analysis object (including runs and predictors)

--- a/pyns/models/analysis.py
+++ b/pyns/models/analysis.py
@@ -474,11 +474,15 @@ class Analyses(Base):
 
         images = self.load_uploads(id, **kwargs)
 
-        plots = []
-        for niimg, entities in images:
-            plots.append(nilearn.plotting.plot_stat_map(niimg, **plot_args))
+        if images:
+            plots = []
+            for niimg, _ in images:
+                plots.append(
+                    nilearn.plotting.plot_stat_map(niimg, **plot_args))
 
-        return plots
+            return plots
+        else:
+            return None
 
     def get_full(self, id):
         """ Get full analysis object (including runs and predictors)

--- a/tests/cassettes/load_analysis.json
+++ b/tests/cassettes/load_analysis.json
@@ -1,0 +1,395 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2021-01-26T23:21:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2MDg4NDY3NTYsImlhdCI6MTYwODI0MTk1NiwibmJmIjoxNjA4MjQxOTU2LCJpZGVudGl0eSI6MX0.IIKlNQgC2YlfKmqMDaNKtyKm2kjpWJZroMebZLXW4Ls"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://neuroscout.org/api/analyses/A13DD"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA32VTW/TQBCG7/yMPRu0X+P15lbRIiEBQrQHJFRFbuJSQxJH/ogoFf+dfZw2NgWRw+vZ8T5j77y78YNatVXZV+tl2auFstrqlzq+tMWVjgutMrUu+7Kr+mW9Vgsb0rjqVm297+tmpxa7YbPJ1F3Z3Y331Zlx5+cJ2jSr71VK3JabrsrUtllXG7V4UG93+6En+DQk+ovJbOYyn8l1pi6Hm2/VKt38orp6rdPPmlTpGIuTU6xlHtsptrO8jafYWD3L+1NsQzHl9cT6OLFiZ/V1mGqaqY528/pTbPzEepPP3nk237hZ/TirOatvZjVnecm1Sn27KrvvqfPb5lBX6lemPpTbKo1vhnqzrndf0/TLvtp3qa8P6nWz69uy6xkl9HzYbu9nuXHCusZaZkw1eMz9nrI9j3hXHbBzNDFT75/M/QxTLlfNdp+kXWreez42z8b22dg9G/tnYzxK77rrlj9O0f0p+pmitunHe1zvH6/kp5Wk179i+m3TbsunlZ425p9rfmxlasqh2RxSdxP98I+uPfbmzcX7s3l7nnb0f6E/Gnp+PGvjgzg09W3974NJJ3d/Gb0v22p3PKnHg7lvq3W9elylUqdE07JqF3TQGWpGtaO6Uf2oklRMQK0ZdczYiDo3Knejd9cUrw/pn+R06tthbK7xTrIkDvFIjgSkQGISrxGDWITJnske1kN4CA/hIQRCIARCIARCIARCIARCIHKIHCKHyCFyiBwih8ghcogcIkAEiAARIAJEgAgQASJABIgCooAoIAqIAqKAKCAKiAKigIgQESJCRIgIESEiRISIEDERojViEIs4xCOC5EhACgTCQBgIA2EgDISBMBAGwkAYCAthISyEhbAQFsJCWAgLYSEchINwENgt2C24L3jOXkkCgeeC54LngueC54LngueC54LngueC54LngueC54LngueC54LnIiHtxK4v+4Et//Hs8vKCD1I33Gzr/ukzdzwdQ1e1aU7b3FRtX75qm9WqfGXUrxe/AU28UsMUBwAA",
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 26 Jan 2021 23:21:45 GMT"
+          ],
+          "Server": [
+            "nginx/1.15.6"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=63072000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "DENY"
+          ],
+          "X-XSS-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://neuroscout.org/api/analyses/A13DD"
+      }
+    },
+    {
+      "recorded_at": "2021-01-26T23:21:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2MDg4NDY3NTYsImlhdCI6MTYwODI0MTk1NiwibmJmIjoxNjA4MjQxOTU2LCJpZGVudGl0eSI6MX0.IIKlNQgC2YlfKmqMDaNKtyKm2kjpWJZroMebZLXW4Ls"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://neuroscout.org/api/analyses/A13DD/upload"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+2Vz0/DIBTH7/4ZnEcD7Ge5eTJG3Yypp2VpGH1dyChtCm2ii/+7dLu4zINzc2saTwR4eXzh++G9+QZJreIaSqtygzgiwSCgqIdkrjVI5xdjlSAe9sekh8A6lQmXlz7QKOuEsz40VRos4vMNWgoLRmTgt52wa5zltYLYFkICfpre0yGbPirDCAnlrX3LYpkbVwrr8LJSOlFmFTc5sdsOmSgCo1SwevdnaKhB+7R3L7PXZz9vAip/KJo9+JlPImEp5BpxU2n90TubFEhT/wrt0VOLUgkj4VRFC29bVqqihOKL+YwEdOt+VehcJJDEwm2XGcWEYsYiSjlDzX1+SE34T00L9FyXmlFEKB8eRQ3dp0akRv0FMl316XyKTn6cXyMzPBKZ8cUKTduoaZGUaxcaOuKDQ2qalAfITMaj/d60izo7LR38021rlN/SsrPzgBSCSYjZJKITTo+pL5P+ZVpS58zpSnHpR4Q1yCxuPgFmLrwXNA0AAA==",
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 26 Jan 2021 23:21:45 GMT"
+          ],
+          "Server": [
+            "nginx/1.15.6"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=63072000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "DENY"
+          ],
+          "X-XSS-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://neuroscout.org/api/analyses/A13DD/upload"
+      }
+    },
+    {
+      "recorded_at": "2021-01-26T23:21:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2MDg4NDY3NTYsImlhdCI6MTYwODI0MTk1NiwibmJmIjoxNjA4MjQxOTU2LCJpZGVudGl0eSI6MX0.IIKlNQgC2YlfKmqMDaNKtyKm2kjpWJZroMebZLXW4Ls"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://neuroscout.org/api/analyses/A13DD/upload"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+2Vz0/DIBTH7/4ZnEcD7Ge5eTJG3Yypp2VpGH1dyChtCm2ii/+7dLu4zINzc2saTwR4eXzh++G9+QZJreIaSqtygzgiwSCgqIdkrjVI5xdjlSAe9sekh8A6lQmXlz7QKOuEsz40VRos4vMNWgoLRmTgt52wa5zltYLYFkICfpre0yGbPirDCAnlrX3LYpkbVwrr8LJSOlFmFTc5sdsOmSgCo1SwevdnaKhB+7R3L7PXZz9vAip/KJo9+JlPImEp5BpxU2n90TubFEhT/wrt0VOLUgkj4VRFC29bVqqihOKL+YwEdOt+VehcJJDEwm2XGcWEYsYiSjlDzX1+SE34T00L9FyXmlFEKB8eRQ3dp0akRv0FMl316XyKTn6cXyMzPBKZ8cUKTduoaZGUaxcaOuKDQ2qalAfITMaj/d60izo7LR38021rlN/SsrPzgBSCSYjZJKITTo+pL5P+ZVpS58zpSnHpR4Q1yCxuPgFmLrwXNA0AAA==",
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 26 Jan 2021 23:21:49 GMT"
+          ],
+          "Server": [
+            "nginx/1.15.6"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=63072000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "DENY"
+          ],
+          "X-XSS-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://neuroscout.org/api/analyses/A13DD/upload"
+      }
+    },
+    {
+      "recorded_at": "2021-01-26T23:22:11",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2MDg4NDY3NTYsImlhdCI6MTYwODI0MTk1NiwibmJmIjoxNjA4MjQxOTU2LCJpZGVudGl0eSI6MX0.IIKlNQgC2YlfKmqMDaNKtyKm2kjpWJZroMebZLXW4Ls"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://neuroscout.org/api/analyses/A13DD/upload"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+2Vz0/DIBTH7/4ZnEcD7Ge5eTJG3Yypp2VpGH1dyChtCm2ii/+7dLu4zINzc2saTwR4eXzh++G9+QZJreIaSqtygzgiwSCgqIdkrjVI5xdjlSAe9sekh8A6lQmXlz7QKOuEsz40VRos4vMNWgoLRmTgt52wa5zltYLYFkICfpre0yGbPirDCAnlrX3LYpkbVwrr8LJSOlFmFTc5sdsOmSgCo1SwevdnaKhB+7R3L7PXZz9vAip/KJo9+JlPImEp5BpxU2n90TubFEhT/wrt0VOLUgkj4VRFC29bVqqihOKL+YwEdOt+VehcJJDEwm2XGcWEYsYiSjlDzX1+SE34T00L9FyXmlFEKB8eRQ3dp0akRv0FMl316XyKTn6cXyMzPBKZ8cUKTduoaZGUaxcaOuKDQ2qalAfITMaj/d60izo7LR38021rlN/SsrPzgBSCSYjZJKITTo+pL5P+ZVpS58zpSnHpR4Q1yCxuPgFmLrwXNA0AAA==",
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 26 Jan 2021 23:22:11 GMT"
+          ],
+          "Server": [
+            "nginx/1.15.6"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=63072000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "DENY"
+          ],
+          "X-XSS-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://neuroscout.org/api/analyses/A13DD/upload"
+      }
+    },
+    {
+      "recorded_at": "2021-01-26T23:22:11",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2MDg4NDY3NTYsImlhdCI6MTYwODI0MTk1NiwibmJmIjoxNjA4MjQxOTU2LCJpZGVudGl0eSI6MX0.IIKlNQgC2YlfKmqMDaNKtyKm2kjpWJZroMebZLXW4Ls"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://neuroscout.org/api/analyses/A13DD/upload"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+2Vz0/DIBTH7/4ZnEcD7Ge5eTJG3Yypp2VpGH1dyChtCm2ii/+7dLu4zINzc2saTwR4eXzh++G9+QZJreIaSqtygzgiwSCgqIdkrjVI5xdjlSAe9sekh8A6lQmXlz7QKOuEsz40VRos4vMNWgoLRmTgt52wa5zltYLYFkICfpre0yGbPirDCAnlrX3LYpkbVwrr8LJSOlFmFTc5sdsOmSgCo1SwevdnaKhB+7R3L7PXZz9vAip/KJo9+JlPImEp5BpxU2n90TubFEhT/wrt0VOLUgkj4VRFC29bVqqihOKL+YwEdOt+VehcJJDEwm2XGcWEYsYiSjlDzX1+SE34T00L9FyXmlFEKB8eRQ3dp0akRv0FMl316XyKTn6cXyMzPBKZ8cUKTduoaZGUaxcaOuKDQ2qalAfITMaj/d60izo7LR38021rlN/SsrPzgBSCSYjZJKITTo+pL5P+ZVpS58zpSnHpR4Q1yCxuPgFmLrwXNA0AAA==",
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 26 Jan 2021 23:22:11 GMT"
+          ],
+          "Server": [
+            "nginx/1.15.6"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=63072000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "DENY"
+          ],
+          "X-XSS-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://neuroscout.org/api/analyses/A13DD/upload"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -247,3 +247,18 @@ def test_upload_analysis(recorder, neuroscout, analysis, get_test_data_path):
 
         assert all([f['status'] == 'OK' for f in newest['files']])
         assert newest['collection_id'] is not None
+
+
+def test_load_analysis(recorder, neuroscout):
+    with recorder.use_cassette('load_analysis'):
+      m = neuroscout.analyses.get_analysis('A13DD')
+      assert len(m.load_uploads()) == 3
+      assert len(m.load_uploads(select=None)) > 3
+      nistats = m.load_uploads(estimator='nistats')
+      latest_up = nistats[0][1]['uploaded_at']
+      assert len(nistats) == 3
+      assert nistats[0][1]['estimator'] == 'nistats'
+
+      old_nistats = m.load_uploads(estimator='nistats', select='oldest')
+
+      assert old_nistats[0][1]['uploaded_at'] < latest_up


### PR DESCRIPTION
Adds `load_uploads` and `plot_uploads` functions to the `Analysis` class, which facilitate downloading statmap images directly from Neurovault collections, and plotting them using nilearn.

`load_uploads` allows you to filter the attributes by which to filter collections you want to load (i.e. only load collections with `estimator` = `afni`), filter the images themselves (i.e. only group images), and loads the resulting imagines in a flat list of tuples across collections, with the first item being a `nibabel.NiftiImage` object. Images are downloaded into a directory which is user specified or a temp directory automatically created.

For example, given a `Analysis` object `m`:

```
m.get_uploads()
[{'cli_version': '0.4.1',
  'collection_id': 9370,
  'estimator': 'nistats',
  'files': [{'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-t_statmap.nii.gz',
    'level': 'GROUP',
    'status': 'OK',
    'traceback': None},
   {'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-effect_statmap.nii.gz',
    'level': 'GROUP',
    'status': 'OK',
    'traceback': None},
   {'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-variance_statmap.nii.gz',
    'level': 'GROUP',
    'status': 'OK',
    'traceback': None}],
  'fmriprep_version': '20.1.1',
  'uploaded_at': '2021-01-22T11:2'},
 {'cli_version': None,
  'collection_id': 8760,
  'estimator': None,
  'files': [{'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-variance_statmap.nii.gz',
    'level': 'GROUP',
    'status': 'OK',
    'traceback': None},
   {'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-t_statmap.nii.gz',
    'level': 'GROUP',
    'status': 'OK',
    'traceback': None},
   {'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-effect_statmap.nii.gz',
    'level': 'GROUP',
    'status': 'OK',
    'traceback': None}],
  'fmriprep_version': None,
  'uploaded_at': '2020-09-28T18:1'},
 {'cli_version': '0.4.1',
  'collection_id': 9383,
  'estimator': 'afni',
  'files': [{'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-t_statmap.nii.gz',
    'level': 'GROUP',
    'status': 'OK',
    'traceback': None},
   {'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-effect_statmap.nii.gz',
    'level': 'GROUP',
    'status': 'OK',
    'traceback': None},
   {'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-variance_statmap.nii.gz',
    'level': 'GROUP',
    'status': 'OK',
    'traceback': None}],
  'fmriprep_version': '20.1.1',
  'uploaded_at': '2021-01-23T02:1'}]
```

In this scenario there are three uploaded collections, with three images each.

By default, only images from the latest collection are loaded:

```
m.load_uploads()

[(<nibabel.nifti1.Nifti1Image at 0x7fc493ad7b50>,
  {'cli_version': '0.4.1',
   'collection_id': 9383,
   'estimator': 'afni',
   'fmriprep_version': '20.1.1',
   'uploaded_at': datetime.datetime(2021, 1, 23, 2, 1),
   'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-t_statmap.nii.gz',
   'level': 'GROUP'}),
 (<nibabel.nifti1.Nifti1Image at 0x7fc493b4b5d0>,
  {'cli_version': '0.4.1',
   'collection_id': 9383,
   'estimator': 'afni',
   'fmriprep_version': '20.1.1',
   'uploaded_at': datetime.datetime(2021, 1, 23, 2, 1),
   'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-effect_statmap.nii.gz',
   'level': 'GROUP'}),
 (<nibabel.nifti1.Nifti1Image at 0x7fc494b76850>,
  {'cli_version': '0.4.1',
   'collection_id': 9383,
   'estimator': 'afni',
   'fmriprep_version': '20.1.1',
   'uploaded_at': datetime.datetime(2021, 1, 23, 2, 1),
   'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-variance_statmap.nii.gz',
   'level': 'GROUP'})]
```

But you can also load all:
```
m.load_uploads(select=None)

[(<nibabel.nifti1.Nifti1Image at 0x7fc493ad7e10>,
  {'cli_version': None,
   'collection_id': 8760,
   'estimator': None,
   'fmriprep_version': None,
   'uploaded_at': datetime.datetime(2020, 9, 28, 18, 1),
   'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-variance_statmap.nii.gz',
   'level': 'GROUP'}),
 (<nibabel.nifti1.Nifti1Image at 0x7fc493ad7650>,
  {'cli_version': None,
   'collection_id': 8760,
   'estimator': None,
   'fmriprep_version': None,
   'uploaded_at': datetime.datetime(2020, 9, 28, 18, 1),
   'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-t_statmap.nii.gz',
   'level': 'GROUP'}),
 (<nibabel.nifti1.Nifti1Image at 0x7fc493ae3b50>,
  {'cli_version': None,
   'collection_id': 8760,
   'estimator': None,
   'fmriprep_version': None,
   'uploaded_at': datetime.datetime(2020, 9, 28, 18, 1),
   'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-effect_statmap.nii.gz',
   'level': 'GROUP'}),
 (<nibabel.nifti1.Nifti1Image at 0x7fc493afbbd0>,
  {'cli_version': '0.4.1',
   'collection_id': 9370,
   'estimator': 'nistats',
   'fmriprep_version': '20.1.1',
   'uploaded_at': datetime.datetime(2021, 1, 22, 11, 2),
   'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-t_statmap.nii.gz',
   'level': 'GROUP'}),
 (<nibabel.nifti1.Nifti1Image at 0x7fc493afbd90>,
  {'cli_version': '0.4.1',
   'collection_id': 9370,
   'estimator': 'nistats',
   'fmriprep_version': '20.1.1',
   'uploaded_at': datetime.datetime(2021, 1, 22, 11, 2),
   'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-effect_statmap.nii.gz',
   'level': 'GROUP'}),
 (<nibabel.nifti1.Nifti1Image at 0x7fc493afdad0>,
  {'cli_version': '0.4.1',
   'collection_id': 9370,
   'estimator': 'nistats',
   'fmriprep_version': '20.1.1',
   'uploaded_at': datetime.datetime(2021, 1, 22, 11, 2),
   'basename': 'task-movie_space-MNI152NLin2009cAsym_contrast-building_stat-variance_statmap.nii.gz',
   'level': 'GROUP'}),
 (<nibabel.nifti1.Nifti1Image at 0x7fc493afd690>,

...
```

`select` can also be `oldest` or `newest` (explicit).

You could also pass a dictionary `coll_filt` to filter the collections. 
e.g.:
```
m.load_uploads(coll_filt={'estimator': 'afni})
```

kwargs can be used to filter the images themselves:

```
m.load_uploads(coll_filt={'estimator': 'afni}, 'level'='GROUP')
```

Finally, `plot_uploads` uses `plot_stat_map` to plot these images:

```
m.plot_uploads()
```
![image](https://user-images.githubusercontent.com/2774448/105651530-bfb1fa80-5e7c-11eb-972e-1951727a5b6a.png)
![image](https://user-images.githubusercontent.com/2774448/105651532-c2aceb00-5e7c-11eb-96de-634cad28e2fc.png)
![image](https://user-images.githubusercontent.com/2774448/105651539-c50f4500-5e7c-11eb-800e-b9142e6fde38.png)

will plot the images from the latest collection. `kwargs` go to `load_uploads` so it can be specified which images to plot. 

@rbroc can you take a look at this and give it a go? 
just want to see if this is useful and it makes sense how I implemented this.

Things still left to do:
- Extract BIDS entities from the file names of images, to allow filtering based on that (i.e. only plot `t` maps, or filter by contrast name
- Maybe make the default plotting parameters better, and add overlays indicating which images is being plotting (you can use `plot_args` to mass arguments to `plot_stat_map`).
Thanks!