### PR TITLE
ENH: Add high-level predictor fetching utilities

### DIFF
--- a/docs/source/_autosummary/pyns.fetch_utils.fetch_images.rst
+++ b/docs/source/_autosummary/pyns.fetch_utils.fetch_images.rst
@@ -1,0 +1,6 @@
+pyns.fetch\_utils.fetch\_images
+===============================
+
+.. currentmodule:: pyns.fetch_utils
+
+.. autofunction:: fetch_images

--- a/docs/source/_autosummary/pyns.fetch_utils.fetch_predictors.rst
+++ b/docs/source/_autosummary/pyns.fetch_utils.fetch_predictors.rst
@@ -1,0 +1,6 @@
+pyns.fetch\_utils.fetch\_predictors
+===================================
+
+.. currentmodule:: pyns.fetch_utils
+
+.. autofunction:: fetch_predictors

--- a/docs/source/_autosummary/pyns.fetch_utils.get_paths.rst
+++ b/docs/source/_autosummary/pyns.fetch_utils.get_paths.rst
@@ -1,0 +1,6 @@
+pyns.fetch\_utils.get\_paths
+============================
+
+.. currentmodule:: pyns.fetch_utils
+
+.. autofunction:: get_paths

--- a/docs/source/_autosummary/pyns.fetch_utils.install_dataset.rst
+++ b/docs/source/_autosummary/pyns.fetch_utils.install_dataset.rst
@@ -1,0 +1,6 @@
+pyns.fetch\_utils.install\_dataset
+==================================
+
+.. currentmodule:: pyns.fetch_utils
+
+.. autofunction:: install_dataset

--- a/docs/source/_autosummary/pyns.fetch_utils.rst
+++ b/docs/source/_autosummary/pyns.fetch_utils.rst
@@ -1,0 +1,33 @@
+﻿pyns.fetch\_utils
+=================
+
+.. automodule:: pyns.fetch_utils
+  
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree:                                          
+   
+      fetch_images
+      fetch_predictors
+      get_paths
+      install_dataset
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,3 +8,4 @@ API
 
    pyns.api
    pyns.endpoints
+   pyns.fetch_utils

--- a/docs/source/fetching.rst
+++ b/docs/source/fetching.rst
@@ -25,10 +25,6 @@ predictors from the Neuroscout API, and the corresponding images from the prepro
 Fetching & re-sampling predictor data
 --------------------------------------
 
-.. note::
-    
-    To learn about low-level utilities for fetching predictors, see the :doc:`querying` documentation.
-
 The method :meth:`pyns.fetch_utils.fetch_predictors` can be used to fetch predictor data, 
 resample it to the TR of the images, and return it as a pandas DataFrame.
 
@@ -38,26 +34,38 @@ Optionally, you can also restrict the data to a subset of subjects, runs or task
 .. code-block:: python
 
     fetch_predictors(predictor_names=['speech', 'rms'], dataset_name='Budapest', 
-        subject='sid000005', run=[1, 2]resample=True)
+        subject='sid000005', run=[1, 2], resample=True, rescale=False)
 
 
-+----+------------+---------+-------+-----------+--------------+--------------+----------+
-|    |   duration |   onset |   run | subject   |          rms |       speech |   run_id |
-+====+============+=========+=======+===========+==============+==============+==========+
-|  0 |          1 |       0 |     1 | sid000005 |  6.18876e-07 |  9.5801e-06  |     1433 |
-+----+------------+---------+-------+-----------+--------------+--------------+----------+
-|  2 |          1 |       1 |     1 | sid000005 | -1.49298e-06 | -2.57011e-05 |     1433 |
-+----+------------+---------+-------+-----------+--------------+--------------+----------+
-|  4 |          1 |       2 |     1 | sid000005 |  3.50004e-06 |  6.755e-05   |     1433 |
-+----+------------+---------+-------+-----------+--------------+--------------+----------+
-|  6 |          1 |       3 |     1 | sid000005 | -7.91888e-06 | -0.000173993 |     1433 |
-+----+------------+---------+-------+-----------+--------------+--------------+----------+
-|  8 |          1 |       4 |     1 | sid000005 |  1.70871e-05 |  0.000439006 |     1433 |
-+----+------------+---------+-------+-----------+--------------+--------------+----------+
+
++----+---------+------------+--------------+--------------+-------+-----------+----------+
+|    |   onset |   duration |       speech |          rms |   run | subject   |   run_id |
++====+=========+============+==============+==============+=======+===========+==========+
+|  0 |       0 |          1 |  9.5801e-06  |  6.18876e-07 |     1 | sid000005 |     1433 |
++----+---------+------------+--------------+--------------+-------+-----------+----------+
+|  2 |       1 |          1 | -2.57011e-05 | -1.49298e-06 |     1 | sid000005 |     1433 |
++----+---------+------------+--------------+--------------+-------+-----------+----------+
+|  4 |       2 |          1 |  6.755e-05   |  3.50004e-06 |     1 | sid000005 |     1433 |
++----+---------+------------+--------------+--------------+-------+-----------+----------+
+|  6 |       3 |          1 | -0.000173993 | -7.91888e-06 |     1 | sid000005 |     1433 |
++----+---------+------------+--------------+--------------+-------+-----------+----------+
+|  8 |       4 |          1 |  0.000439006 |  1.70871e-05 |     1 | sid000005 |     1433 |
++----+---------+------------+--------------+--------------+-------+-----------+----------+
+
 
 This will return a pandas DataFrame with the predictors resampled to the TR (in this case 0.33s) 
-ith `onset` and `duration` columns. In addition, columns describing the entities identifying each columns
-(e.g. which run, subject, etc...) are included as columns.
+with `onset` and `duration` columns. In addition, columns describing the entities identifying each columns
+(e.g. `subject`, `run`...) are included as columns.
+
+Note that you can choose to rescale the predictors to have a mean of 0 and standard deviation of 1, by setting
+`rescale=True`. This operation will occur prior to densification and resampling of variables.
+
+It's possible to retrieve `BIDSRunVariableCollection` collection (`return_type='collection'`), which can be used to
+apply further transformations to the data.
+
+.. note::
+    
+    To learn about low-level utilities for fetching predictors, see the :doc:`querying` documentation.
 
 -----------------------------
 Fetching preprocessed images

--- a/docs/source/fetching.rst
+++ b/docs/source/fetching.rst
@@ -1,0 +1,107 @@
+Fetching predictors & images
+=============================
+
+To facilitate creating custom analysis workflows, `pyNS` provides a number of high-level utilities for fetching 
+predictors from the Neuroscout API, and the corresponding images from the preprocessed BIDS dataset.
+
+.. note::
+
+    Analysis pipelines created using these utilities will not be centrally registered on Neuroscout, and 
+    will not be available to other users by the Neuroscout API or web interface.
+
+    If your analysis type is supported by `Neuroscout-CLI <https://neuroscout-cli.readthedocs.io/en/latest/>`_ 
+    (e.g. summary statistics GLM), it is recommended to use the 
+    web interface to create your analysis or the follow the guide for :doc:`analyses` using pyNS.
+
+    If you use these data in a publication, please cite the following paper:
+    
+    Alejandro de la Vega, Roberta Rocca, Ross W Blair, Christopher J Markiewicz, Jeff Mentch, James D Kent, Peer Herholz, Satrajit S Ghosh, Russell A Poldrack, Tal Yarkoni (2022). *Neuroscout, a unified platform for generalizable and reproducible fMRI research*. eLife 11:e79277
+    https://doi.org/10.7554/eLife.79277
+
+    In addition, please cite the original dataset(s), and the predictor extractors you use.
+
+
+--------------------------------------
+Fetching & re-sampling predictor data
+--------------------------------------
+
+.. note::
+    
+    To learn about low-level utilities for fetching predictors, see the :doc:`querying` documentation.
+
+The method :meth:`pyns.fetch_utils.fetch_predictors` can be used to fetch predictor data, 
+resample it to the TR of the images, and return it as a pandas DataFrame.
+
+You only need two things: a list of predictors, and the name of the BIDS dataset.
+Optionally, you can also restrict the data to a subset of subjects, runs or tasks (reccomended for testing).
+
+.. code-block:: python
+
+    fetch_predictors(predictor_names=['speech', 'rms'], dataset_name='Budapest', 
+        subject='sid000005', run=[1, 2]resample=True)
+
+
++----+------------+---------+-------+-----------+--------------+--------------+----------+
+|    |   duration |   onset |   run | subject   |          rms |       speech |   run_id |
++====+============+=========+=======+===========+==============+==============+==========+
+|  0 |          1 |       0 |     1 | sid000005 |  6.18876e-07 |  9.5801e-06  |     1433 |
++----+------------+---------+-------+-----------+--------------+--------------+----------+
+|  2 |          1 |       1 |     1 | sid000005 | -1.49298e-06 | -2.57011e-05 |     1433 |
++----+------------+---------+-------+-----------+--------------+--------------+----------+
+|  4 |          1 |       2 |     1 | sid000005 |  3.50004e-06 |  6.755e-05   |     1433 |
++----+------------+---------+-------+-----------+--------------+--------------+----------+
+|  6 |          1 |       3 |     1 | sid000005 | -7.91888e-06 | -0.000173993 |     1433 |
++----+------------+---------+-------+-----------+--------------+--------------+----------+
+|  8 |          1 |       4 |     1 | sid000005 |  1.70871e-05 |  0.000439006 |     1433 |
++----+------------+---------+-------+-----------+--------------+--------------+----------+
+
+This will return a pandas DataFrame with the predictors resampled to the TR (in this case 0.33s) 
+ith `onset` and `duration` columns. In addition, columns describing the entities identifying each columns
+(e.g. which run, subject, etc...) are included as columns.
+
+-----------------------------
+Fetching preprocessed images
+-----------------------------
+
+.. note::
+    
+    Datalad is required to download images. See `DataLad documentation <https://handbook.datalad.org>`_
+    for installation instructions.
+
+The method :meth:`pyns.fetch_utils.fetch_images` facilitates downloading preprocessed images from the
+Neuroscout datasets. It can be used to download images for a single subject, or for all subjects in a
+dataset.
+
+Simply provide a directory where Neuroscout datasets should be installed, and the dataset name.
+Optionally, you can also restrict the data to a subset of subjects, runs or tasks (reccomended for testing).
+
+.. code-block:: python
+    
+    preproc_dir, img_paths = fetch_images('Budapest', '/tmp/', subject=subject)
+    img_paths[0]
+    
+    <BIDSImageFile filename='/tmp/Budapest/fmriprep/sub-sid000005/func/sub-sid000005_task-movie_run-1_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz'>
+
+:meth:`pyns.fetch_utils.fetch_images` installs the dataset using datalad, and returns the path to the 
+preprocessed dataset, as well as a list of `BIDSImageFile` objects for each image.
+
+The `BIDSImageFile` objects can be used to load the images into memory using `nibabel <https://nipy.org/nibabel/>`_, 
+and can be used to extract metadata about the image, such as the associated entities:
+
+.. code-block:: python
+
+    target = img_paths[0]
+    img = target.get_image()
+    target.get_entities()
+    
+     {'datatype': 'func',
+      'desc': 'preproc',
+      'extension': '.nii.gz',
+      'run': 1,
+      'space': 'MNI152NLin2009cAsym',
+      'subject': 'sid000005',
+      'suffix': 'bold',
+      'task': 'movie'}
+
+
+Using these methods you can easily create custom analysis workflows. 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
 pyNS: Neuroscout API client documentation
-===================================
+=========================================
 
 .. image:: neuroscout-logo.svg
   :width: 400

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-Welcome to pyNS's documentation!
+pyNS: Neuroscout API client documentation
 ===================================
 
 .. image:: neuroscout-logo.svg
@@ -6,10 +6,15 @@ Welcome to pyNS's documentation!
   :alt: Neuroscout Logo
 
 
-**pyNS** is the Python client library for accessing the `Neuroscout API <https://neuroscout.org/api>`_
- 
-**pyNS** enables advanced used cases not supported by the `neuroscout.org <https://neuroscout.org>`_
-web-based analysis builder, such as batch-creation of analyses, or meta-analytic applications.
+**pyNS** is the Python client for the `Neuroscout API <https://neuroscout.org/api>`_, allowing users 
+to programmatically query and interactive with the Neuroscout database. This allows users to
+create analyses, query for analyses, and download analysis results.
+
+**pyNS** provides a number of high-level functions for common tasks (that would typically require 
+multiple API calls), such as creating and registering analyses, and fetching predictor and imaging data directly.
+
+Advanced use cases include: batch-creation of analyses (e.g. for meta-analysis) and the
+creation of custom analysis pipelines.
 
 **pyNS** mirrors the official Neuroscout API with a Pythonic interface.
 Note that the best reference for the API is the official `API docs <https://neuroscout.org/api>`_
@@ -30,4 +35,5 @@ Contents
    quickstart
    querying
    analyses
+   fetching
    api

--- a/docs/source/querying.rst
+++ b/docs/source/querying.rst
@@ -84,6 +84,10 @@ Under the hood, `pyNS` looks up the ``dataset_id`` and ``task_id`` for the given
 Getting the predictor data
 ----------------------------------
 
+.. note::
+    
+    High-level utilities are available to facilitate this process. See the :doc:`fetching` documentation.
+
 An important aspect of `pyNS` is the ability to retrieve moment by moment events for specific predictors.
 
 The simplest way is to simply use ``predictor_id`` to query for a specific Predictor, for a specific ``run_id``:

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,0 +1,2 @@
+pybids
+pandas

--- a/pyns/__init__.py
+++ b/pyns/__init__.py
@@ -8,7 +8,7 @@ ROUTE_PATTERN = '{base_url}/{route}[/{id}][/{sub_route}]'
 from .api import Neuroscout
 from . import endpoints
 
-__all__ = ['Neuroscout', 'endpoints']
+__all__ = ['Neuroscout', 'endpoints', 'fetch_utils']
 
 __author__ = ['Alejandro de la Vega']
 __license__ = 'MIT'

--- a/pyns/endpoints/base.py
+++ b/pyns/endpoints/base.py
@@ -153,7 +153,7 @@ def _id_to_entities(df):
                 names = {
                     r: endpoint.get(r)['name'] 
                     for r in df[col].unique()
-                    if r is not None
+                    if r
                     }
                 df[col.replace('_id', '_name')] = df[col].map(names)
     return df

--- a/pyns/endpoints/base.py
+++ b/pyns/endpoints/base.py
@@ -153,7 +153,7 @@ def _id_to_entities(df):
                 names = {
                     r: endpoint.get(r)['name'] 
                     for r in df[col].unique()
-                    if df[col].unique() is not None
+                    if r is not None
                     }
                 df[col.replace('_id', '_name')] = df[col].map(names)
     return df

--- a/pyns/endpoints/base.py
+++ b/pyns/endpoints/base.py
@@ -152,8 +152,7 @@ def _id_to_entities(df):
             else:
                 names = {
                     r: endpoint.get(r)['name'] 
-                    for r in df[col].unique()
-                    if r
+                    for r in df[col].dropna().unique()
                     }
                 df[col.replace('_id', '_name')] = df[col].map(names)
     return df

--- a/pyns/endpoints/base.py
+++ b/pyns/endpoints/base.py
@@ -153,6 +153,7 @@ def _id_to_entities(df):
                 names = {
                     r: endpoint.get(r)['name'] 
                     for r in df[col].unique()
+                    if df[col].unique() is not None
                     }
                 df[col.replace('_id', '_name')] = df[col].map(names)
     return df

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -50,7 +50,7 @@ def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df',
         
     # Create BIDSRunVariableCollection
     variables = []
-    for (run_id, predictor_names), df in all_df.groupby(['run_id', 'predictor_names']):
+    for (run_id, predictor_names), df in all_df.groupby(['run_id', 'predictor_name']):
         # Determine entities / run info
         keep_cols = []
         entities = {}

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -26,18 +26,12 @@ def fetch_predictors(predictor_names, dataset_name, return_type='df',
     BIDSRunVariableCollection or pandas DataFrame
 
     Args:
-        predictor_names : str
-            Name of predictors to fetch
-        dataset_name : str
-            Name of dataset to fetch predictors from
-        return_type : str
-            Either 'df' or 'BIDSRunVariableCollection'
-        resample : bool
-            Whether to resample predictors to TR
-        api : pyns.Neuroscout
-            Authenticated instance of Neuroscout API (if None, will create one)
-        entities : dict
-            Entities to filter by. Can include 'subject', 'session', 'run',
+        predictor_names (str): Mame of predictors to fetch
+        dataset_name (str): Name of dataset to fetch predictors from
+        return_type (str): Either 'df' or 'BIDSRunVariableCollection'
+        resample (bool): Whether to resample predictors to TR
+        api (pyns.Neuroscout): A instance of API (if None, will create one)
+        entities (dict): Entities to filter by. e.g.: 'subject', 'session', 'run',
     """
     if api is None:
         api = Neuroscout()
@@ -145,7 +139,7 @@ def get_paths(preproc_dir, fetch_json=False, fetch_brain_mask=False, **entities)
 
 def install_dataset(dataset_dir, preproc_address, no_get=False):
     """ Install a Neuroscout dataset using DataLad.
-    
+
     Args:
         dataset_dir (str): Path to install dataset
         preproc_address (str): URL to install dataset from
@@ -190,7 +184,7 @@ def fetch_images(dataset_name, data_dir, no_get=False, datalad_jobs=-1,
         no_get (bool): Whether to skip fetching (i.e. dry run)
         datalad_jobs (int): Number of jobs to use for DataLad download
         preproc_address (str): URL to install dataset from. Fetched from API if not provided.
-        **kwargs: Additional arguments to pass to get_paths, including filters
+        kwargs: Additional arguments to pass to get_paths, including filters
         (e.g. subjects, runs, tasks)
 
     Returns:

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -100,7 +100,7 @@ def get_paths(preproc_dir, fetch_json=False, fetch_brain_mask=False, **entities)
     preproc_dir = Path(preproc_dir)
     paths = []
     
-    layout = BIDSLayout(preproc_dir, derivatives=BIDSLayout, index_metadata=False)
+    layout = BIDSLayout(preproc_dir, derivatives=preproc_dir, index_metadata=False)
     
     # Identify functional runs
     paths = layout.get(desc='preproc', extension='.nii.gz', suffix='bold', 

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -9,7 +9,7 @@ from pyns import Neuroscout
 from datalad.api import install, get
 from pathlib import Path
 
-def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df', 
+def fetch_predictors(predictor_names, dataset_name, return_type='df', 
     resample=True, api=None, **entities):
     """ Fetch predictors from Neuroscout API, and return as a 
     BIDSRunVariableCollection or pandas DataFrame

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -1,10 +1,12 @@
 """ High-level utilities for fetching predictors from Neuroscout API """
 import math
+import warnings
 import pandas as pd
 from bids.variables import SparseRunVariable, BIDSRunVariableCollection
 from bids.variables.entities import RunInfo
 from pyns import Neuroscout
-
+from datalad.api import install, get
+from pathlib import Path
 
 def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df', resample=True, api=None, **entities):
     """ Fetch predictors from Neuroscout API, and return as a BIDSRunVariableCollection or pandas DataFrame
@@ -81,3 +83,134 @@ def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df',
         collection = collection.sort_values(sort_keys)
 
     return collection
+
+
+def get_paths(preproc_dir, fetch_json=False, subjects=None, runs=None, tasks=None):
+    """ Get paths to preprocessed images in a Neuroscout dataset.
+    Args:
+        preproc_dir (str): Path to preprocessed dataset
+        fetch_json (bool): Whether to fetch JSON metadata files
+        subjects (list or str): List of subjects to fetch
+        runs (list or str): List of runs to fetch
+        tasks (list or str): List of tasks to fetch
+    
+    Returns:
+        paths: List of paths to images
+    """
+    preproc_dir = Path(preproc_dir)
+    paths = []
+    
+
+    if tasks is None:
+        tasks = ''
+    if not isinstance(tasks, list):
+        tasks = [tasks]
+    tasks = [f'task-{t}*' for t in tasks]
+    
+    if not subjects:
+        subjects = '*'
+    if not isinstance(subjects, list):
+        subjects = [subjects]
+    
+    if not runs:
+        runs = ''
+    if not isinstance(runs, list):
+        runs = [runs]
+        
+    run_p = [f'run-{r}*'  if r else r for r in runs]
+    run_p += [f'run-{str(r).zfill(2)}*' if r else r for r in runs]
+    runs = list(set(run_p))
+    
+    for sub in subjects:
+        for run in runs:
+            for task in tasks:
+                pre =  f'sub-{sub}/**/func/*{task}{run}space-MNI152NLin2009cAsym*'
+                paths += list(preproc_dir.glob(pre + 'preproc*.nii.gz'))
+                paths += list(preproc_dir.glob(pre + 'brain_mask.nii.gz'))
+
+    if not paths:
+        raise Exception("No images suitable for download.")
+    
+    if fetch_json:
+        # Get all JSON files in Dataset just in case
+        paths += list(preproc_dir.rglob('*.json'))
+    
+    # Check for correctness:
+    errors = [1 if not p.is_symlink() else 0 for p in paths]
+    if sum(errors) > 0:
+        warnings.warn("Error computing image paths. Attempt fetch anyways.")
+    
+    return paths
+
+def install_dataset(dataset_dir, preproc_address, no_get=False):
+    """ Install a Neuroscout dataset using DataLad.
+    Args:
+        dataset_dir (str): Path to install dataset
+        preproc_address (str): URL to install dataset from
+        no_get (bool): Whether to skip installation (i.e. dry run)
+
+    Returns:
+        preproc_dir (str): Path to preprocessed folder (i.e. fmriprep or preproc)
+    """
+    dataset_dir = Path(dataset_dir)
+    # Install DataLad dataset if dataset_dir does not exist
+    if not dataset_dir.exists() and not no_get:
+        # Use datalad to install the preproc dataset
+        install(source=preproc_address,
+                path=str(dataset_dir))
+
+    for option in ['preproc', 'fmriprep']:
+        if (dataset_dir / option).exists():
+            preproc_dir = (dataset_dir / option).absolute()
+            break
+    else:
+        preproc_dir = dataset_dir
+        
+    return preproc_dir
+
+
+def fetch_preproc(dataset_name, data_dir, no_get=False, datalad_jobs=-1, **filters):
+    """ Fetch preprocessed images from a Neuroscout dataset.
+    Installs dataset using DataLad if not already installed.
+    
+    Args:
+        dataset_name (str): Name of dataset to fetch
+        data_dir (str): Path to datasets directories. Dataset will be installed
+            in data_dir / dataset_name if not already installed.
+        no_get (bool): Whether to skip fetching (i.e. dry run)
+        datalad_jobs (int): Number of jobs to use for DataLad download
+        **filters: Additional filters to pass to get_paths (e.g. subjects, runs, tasks)
+
+    Returns:
+        paths (Path object): List of paths to images 
+    
+    Examples:
+        >>> from pyns.fetch_utils import fetch_preproc
+        >>> paths = fetch_preproc('Budapest', '/data/neuroscout', subjects='sid000005', runs=[1, 2])
+        >>> paths
+        [PosixPath('/data/neuroscout/Budapest/fmriprep/sub-sid000005/func/sub-sid000005_task-movie_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz'),
+        ...
+        ]
+    """
+    api = Neuroscout()
+    preproc_address = api.datasets.get(name=dataset_name)[0]['preproc_address']
+    data_dir = Path(data_dir)
+    dataset_dir = data_dir / dataset_name
+    
+    preproc_dir = install_dataset(dataset_dir, preproc_address, no_get=no_get)
+    
+    paths = get_paths(preproc_dir, **filters)
+    
+    try:
+        # Get with DataLad
+        if not no_get:
+            get([str(p) for p in paths], dataset=dataset_dir, jobs=datalad_jobs)
+
+    except Exception as exp:
+        if hasattr(exp, 'failed'):
+            message = exp.failed[0]['message']
+            raise ValueError("Datalad failed. Reason: {}".format(message))
+        else:
+            raise exp
+            
+    return paths

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -79,4 +79,4 @@ def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df',
         collection = collection.to_df()
         collection = collection.sort_values(['subject', 'session', 'run', 'acquisition', 'onset'])
 
-    return 
+    return collection

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -186,9 +186,11 @@ def fetch_preproc(dataset_name, data_dir, no_get=False, datalad_jobs=-1, **filte
     
     Examples:
         >>> from pyns.fetch_utils import fetch_preproc
-        >>> paths = fetch_preproc('Budapest', '/data/neuroscout', subjects='sid000005', runs=[1, 2])
+        >>> paths = fetch_preproc(
+                'Budapest', '/data/neuroscout', subjects='sid000005', runs=[1, 2])
         >>> paths
-        [PosixPath('/data/neuroscout/Budapest/fmriprep/sub-sid000005/func/sub-sid000005_task-movie_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz'),
+        [PosixPath('/data/neuroscout/Budapest/fmriprep/sub-sid000005/func/ \ 
+        sub-sid000005_task-movie_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz'),
         ...
         ]
     """

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -31,7 +31,7 @@ def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df',
 
     # Fetch from API
     all_df = api.predictor_events.get(
-        predictor_name=predictor_name, dataset_name=dataset_name, output_type='df', **entities)
+        predictor_names=predictor_names, dataset_name=dataset_name, output_type='df', **entities)
     all_df = all_df.rename(columns={'number': 'run', 'value': 'amplitude'})
     
     # Get run-level metadata
@@ -50,7 +50,7 @@ def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df',
         
     # Create BIDSRunVariableCollection
     variables = []
-    for (run_id, predictor_name), df in all_df.groupby(['run_id', 'predictor_name']):
+    for (run_id, predictor_names), df in all_df.groupby(['run_id', 'predictor_names']):
         # Determine entities / run info
         keep_cols = []
         entities = {}
@@ -68,7 +68,7 @@ def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df',
         
         df = df[['onset', 'duration', 'amplitude'] + keep_cols].sort_values('onset')
         variables.append(SparseRunVariable(
-            predictor_name, df, run_info, 'events'))
+            predictor_names, df, run_info, 'events'))
             
     collection = BIDSRunVariableCollection(variables=variables)
 

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -184,7 +184,7 @@ def fetch_images(dataset_name, data_dir, no_get=False, datalad_jobs=-1,
     
     Args:
         dataset_name (str): Name of dataset to fetch.
-        data_dir (str): Path to datasets directories. Dataset will be installed.
+        data_dir (str): Path to datasetim s directories. Dataset will be installed.
         in data_dir / dataset_name if not already installed.
         no_get (bool): Whether to skip fetching (i.e. dry run).
         datalad_jobs (int): Number of jobs to use for DataLad download.

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -77,6 +77,7 @@ def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df',
 
     if return_type == 'df':
         collection = collection.to_df()
-        collection = collection.sort_values(['subject', 'session', 'run', 'acquisition', 'onset'])
+        sort_keys = [a for a in ['subject', 'session', 'run', 'acquisition', 'onset'] if a in collection.columns]
+        collection = collection.sort_values(sort_keys)
 
     return collection

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -88,8 +88,7 @@ def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df',
     return collection
 
 
-def get_paths(preproc_dir, fetch_json=False, 
-    fetch_brain_mask=False, **entities):
+def get_paths(preproc_dir, fetch_json=False, fetch_brain_mask=False, **entities):
     """ Get paths to preprocessed images in a Neuroscout dataset.
     Args:
         preproc_dir (str): Path to preprocessed dataset
@@ -150,7 +149,7 @@ def install_dataset(dataset_dir, preproc_address, no_get=False):
     return preproc_dir
 
 
-def fetch_preproc(dataset_name, data_dir, no_get=False, datalad_jobs=-1, 
+def fetch_images(dataset_name, data_dir, no_get=False, datalad_jobs=-1, 
     preproc_address=None, **kwargs):
     """ Fetch preprocessed images from a Neuroscout dataset.
     Installs dataset using DataLad if not already installed.
@@ -167,15 +166,15 @@ def fetch_preproc(dataset_name, data_dir, no_get=False, datalad_jobs=-1,
 
     Returns:
         preproc_dir (str): Path to preprocessed folder (i.e. fmriprep or preproc)
-        paths (Path object): List of paths to images 
+        paths (Path object): List of BIDSImageFile objects corresponding to fetched files 
     
     Examples:
         >>> from pyns.fetch_utils import fetch_preproc
         >>> preproc_dir, paths = fetch_preproc(
                 'Budapest', '/data/neuroscout', subjects='sid000005', runs=[1, 2])
         >>> paths
-        [PosixPath('/data/neuroscout/Budapest/fmriprep/sub-sid000005/func/ \ 
-        sub-sid000005_task-movie_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz'),
+        [<BIDSImageFile filename='/tmp/Budapest/fmriprep/sub-sid000005/\ 
+        func/sub-sid000005_task-movie_run-1_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz'>, 
         ...
         ]
     """

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -2,12 +2,24 @@
 import math
 import warnings
 import pandas as pd
-from bids.variables import SparseRunVariable, BIDSRunVariableCollection
-from bids.variables.entities import RunInfo
-from bids.layout import BIDSLayout
 from pyns import Neuroscout
-from datalad.api import install, get
 from pathlib import Path
+
+try:
+    from bids.variables import SparseRunVariable, BIDSRunVariableCollection
+    from bids.variables.entities import RunInfo
+    from bids.layout import BIDSLayout
+except ImportError:
+    SparseRunVariable = None
+    BIDSRunVariableCollection = None
+    RunInfo = None
+    BIDSLayout = None
+
+try:
+    from datalad.api import install, get
+except ImportError:
+    install = None
+    get = None
 
 def fetch_predictors(predictor_names, dataset_name, return_type='df', 
     resample=True, api=None, **entities):
@@ -31,6 +43,9 @@ def fetch_predictors(predictor_names, dataset_name, return_type='df',
     """
     if api is None:
         api = Neuroscout()
+
+    if SparseRunVariable is None:
+        raise ImportError("bids.variables is required to fetch predictors. Please install pybids.")
 
     # Fetch from API
     if 'run' in entities:
@@ -106,6 +121,9 @@ def get_paths(preproc_dir, fetch_json=False, fetch_brain_mask=False, **entities)
     """
     preproc_dir = Path(preproc_dir)
     paths = []
+
+    if BIDSLayout is None:
+        raise ImportError("pybids is required to query dataset and associate with meta-data.")
     
     layout = BIDSLayout(preproc_dir, derivatives=preproc_dir, index_metadata=False)
     
@@ -136,6 +154,10 @@ def install_dataset(dataset_dir, preproc_address, no_get=False):
     Returns:
         preproc_dir (str): Path to preprocessed folder (i.e. fmriprep or preproc)
     """
+
+    if install is None:
+        raise Exception("Install datalad to use this function")
+
     dataset_dir = Path(dataset_dir)
     # Install DataLad dataset if dataset_dir does not exist
     if not dataset_dir.exists() and not no_get:

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -26,13 +26,13 @@ def fetch_predictors(predictor_names, dataset_name, return_type='df', rescale=Fa
     BIDSRunVariableCollection or pandas DataFrame
 
     Args:
-        predictor_names (str): Mame of predictors to fetch
-        dataset_name (str): Name of dataset to fetch predictors from
-        return_type (str): Either 'df' or 'BIDSRunVariableCollection'
-        rescale (bool): Whether to rescale predictors to mean 0, std 1
-        resample (bool): Whether to resample predictors to TR
-        api (pyns.Neuroscout): A instance of API (if None, will create one)
-        entities (dict): Entities to filter by. e.g.: 'subject', 'session', 'run',
+        predictor_names (str): Mame of predictors to fetch.
+        dataset_name (str): Name of dataset to fetch predictors from.
+        return_type (str): Either 'df' or 'BIDSRunVariableCollection'.
+        rescale (bool): Whether to rescale predictors to mean 0, std 1.
+        resample (bool): Whether to resample predictors to TR.
+        api (pyns.Neuroscout): A instance of API (if None, will create one).
+        entities (dict): Entities to filter by. e.g.: 'subject', 'session', 'run'.
     """
     if api is None:
         api = Neuroscout()
@@ -111,11 +111,11 @@ def get_paths(preproc_dir, fetch_json=False, fetch_brain_mask=False, **entities)
     """ Get paths to preprocessed images in a Neuroscout dataset.
 
     Args:
-        preproc_dir (str): Path to preprocessed dataset
-        fetch_json (bool): Whether to fetch JSON metadata files
-        entities (dict): Entities to filter by
+        preproc_dir (str): Path to preprocessed dataset.
+        fetch_json (bool): Whether to fetch JSON metadata files.
+        entities (dict): Entities to filter by.
     Returns:
-        paths: List of BIDSFile objects to fetch
+        paths: List of BIDSFile objects to fetch.
     """
     preproc_dir = Path(preproc_dir)
     paths = []
@@ -146,12 +146,12 @@ def install_dataset(dataset_dir, preproc_address, no_get=False):
     """ Install a Neuroscout dataset using DataLad.
 
     Args:
-        dataset_dir (str): Path to install dataset
-        preproc_address (str): URL to install dataset from
-        no_get (bool): Whether to skip installation (i.e. dry run)
+        dataset_dir (str): Path to install dataset.
+        preproc_address (str): URL to install dataset from.
+        no_get (bool): Whether to skip installation (i.e. dry run).
 
     Returns:
-        preproc_dir (str): Path to preprocessed folder (i.e. fmriprep or preproc)
+        preproc_dir (str): Path to preprocessed folder (i.e. fmriprep or preproc).
     """
 
     if install is None:
@@ -183,14 +183,14 @@ def fetch_images(dataset_name, data_dir, no_get=False, datalad_jobs=-1,
     Installs dataset using DataLad if not already installed.
     
     Args:
-        dataset_name (str): Name of dataset to fetch
-        data_dir (str): Path to datasets directories. Dataset will be installed
+        dataset_name (str): Name of dataset to fetch.
+        data_dir (str): Path to datasets directories. Dataset will be installed.
         in data_dir / dataset_name if not already installed.
-        no_get (bool): Whether to skip fetching (i.e. dry run)
-        datalad_jobs (int): Number of jobs to use for DataLad download
+        no_get (bool): Whether to skip fetching (i.e. dry run).
+        datalad_jobs (int): Number of jobs to use for DataLad download.
         preproc_address (str): URL to install dataset from. Fetched from API if not provided.
         kwargs: Additional arguments to pass to get_paths, including filters
-        (e.g. subjects, runs, tasks)
+        (e.g. subjects, runs, tasks).
 
     Returns:
         preproc_dir (str): Path to preprocessed folder (i.e. fmriprep or preproc)

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -31,7 +31,7 @@ def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df',
 
     # Fetch from API
     all_df = api.predictor_events.get(
-        predictor_names=predictor_names, dataset_name=dataset_name, output_type='df', **entities)
+        predictor_name=predictor_names, dataset_name=dataset_name, output_type='df', **entities)
     all_df = all_df.rename(columns={'number': 'run', 'value': 'amplitude'})
     
     # Get run-level metadata

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -1,0 +1,82 @@
+""" High-level utilities for fetching predictors from Neuroscout API """
+import math
+import pandas as pd
+from bids.variables import SparseRunVariable, BIDSRunVariableCollection
+from bids.variables.entities import RunInfo
+from pyns import Neuroscout
+
+
+def fetch_neuroscout_predictors(predictor_names, dataset_name, return_type='df', resample=True, api=None, **entities):
+    """ Fetch predictors from Neuroscout API, and return as a BIDSRunVariableCollection or pandas DataFrame
+
+    Parameters
+    ----------
+    predictor_names : str
+        Name of predictors to fetch
+    dataset_name : str
+        Name of dataset to fetch predictors from
+    return_type : str
+        Either 'df' or 'BIDSRunVariableCollection'
+    resample : bool
+        Whether to resample predictors to TR
+    api : pyns.Neuroscout
+        Authenticated instance of Neuroscout API (if None, will create one)
+    entities : dict
+        Entities to filter by
+
+
+    """
+    if api is None:
+        api = Neuroscout()
+
+    # Fetch from API
+    all_df = api.predictor_events.get(
+        predictor_name=predictor_name, dataset_name=dataset_name, output_type='df', **entities)
+    all_df = all_df.rename(columns={'number': 'run', 'value': 'amplitude'})
+    
+    # Get run-level metadata
+    all_run_info = {}
+    for run_id in all_df.run_id.unique():
+        resp = api.runs.get(run_id)
+        ri = {
+            'duration': resp['duration'],
+            'tr': api.tasks.get(resp['task'])['TR'],
+            'image': None
+        }
+        
+        # TODO: Fetch real number of volumes, or allowing passing it in
+        ri['n_vols'] = math.ceil(ri['duration'] / ri['tr'])
+        all_run_info[run_id] = ri
+        
+    # Create BIDSRunVariableCollection
+    variables = []
+    for (run_id, predictor_name), df in all_df.groupby(['run_id', 'predictor_name']):
+        # Determine entities / run info
+        keep_cols = []
+        entities = {}
+        for j in ['subject', 'session', 'run', 'acquisition', 'run_id']:
+            val = df[j].iloc[0]
+            if val:
+                entities[j] = val
+                keep_cols.append(j)
+        run_info = RunInfo(**all_run_info[run_id], entities=entities)
+
+        try:
+            df['amplitude'] = pd.to_numeric(df['amplitude'])
+        except ValueError:
+            pass
+        
+        df = df[['onset', 'duration', 'amplitude'] + keep_cols].sort_values('onset')
+        variables.append(SparseRunVariable(
+            predictor_name, df, run_info, 'events'))
+            
+    collection = BIDSRunVariableCollection(variables=variables)
+
+    if resample:
+        collection = collection.to_dense().resample('TR')
+
+    if return_type == 'df':
+        collection = collection.to_df()
+        collection = collection.sort_values(['subject', 'session', 'run', 'acquisition', 'onset'])
+
+    return 

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -1,6 +1,5 @@
 """ High-level utilities for fetching predictors from Neuroscout API """
 import math
-import warnings
 import pandas as pd
 from pyns import Neuroscout
 from pathlib import Path
@@ -26,20 +25,19 @@ def fetch_predictors(predictor_names, dataset_name, return_type='df',
     """ Fetch predictors from Neuroscout API, and return as a 
     BIDSRunVariableCollection or pandas DataFrame
 
-    Parameters
-    ----------
-    predictor_names : str
-        Name of predictors to fetch
-    dataset_name : str
-        Name of dataset to fetch predictors from
-    return_type : str
-        Either 'df' or 'BIDSRunVariableCollection'
-    resample : bool
-        Whether to resample predictors to TR
-    api : pyns.Neuroscout
-        Authenticated instance of Neuroscout API (if None, will create one)
-    entities : dict
-        Entities to filter by. Can include 'subject', 'session', 'run',
+    Args:
+        predictor_names : str
+            Name of predictors to fetch
+        dataset_name : str
+            Name of dataset to fetch predictors from
+        return_type : str
+            Either 'df' or 'BIDSRunVariableCollection'
+        resample : bool
+            Whether to resample predictors to TR
+        api : pyns.Neuroscout
+            Authenticated instance of Neuroscout API (if None, will create one)
+        entities : dict
+            Entities to filter by. Can include 'subject', 'session', 'run',
     """
     if api is None:
         api = Neuroscout()
@@ -112,6 +110,7 @@ def fetch_predictors(predictor_names, dataset_name, return_type='df',
 
 def get_paths(preproc_dir, fetch_json=False, fetch_brain_mask=False, **entities):
     """ Get paths to preprocessed images in a Neuroscout dataset.
+
     Args:
         preproc_dir (str): Path to preprocessed dataset
         fetch_json (bool): Whether to fetch JSON metadata files
@@ -146,6 +145,7 @@ def get_paths(preproc_dir, fetch_json=False, fetch_brain_mask=False, **entities)
 
 def install_dataset(dataset_dir, preproc_address, no_get=False):
     """ Install a Neuroscout dataset using DataLad.
+    
     Args:
         dataset_dir (str): Path to install dataset
         preproc_address (str): URL to install dataset from
@@ -186,12 +186,12 @@ def fetch_images(dataset_name, data_dir, no_get=False, datalad_jobs=-1,
     Args:
         dataset_name (str): Name of dataset to fetch
         data_dir (str): Path to datasets directories. Dataset will be installed
-            in data_dir / dataset_name if not already installed.
+        in data_dir / dataset_name if not already installed.
         no_get (bool): Whether to skip fetching (i.e. dry run)
         datalad_jobs (int): Number of jobs to use for DataLad download
         preproc_address (str): URL to install dataset from. Fetched from API if not provided.
         **kwargs: Additional arguments to pass to get_paths, including filters
-         (e.g. subjects, runs, tasks)
+        (e.g. subjects, runs, tasks)
 
     Returns:
         preproc_dir (str): Path to preprocessed folder (i.e. fmriprep or preproc)

--- a/pyns/fetch_utils.py
+++ b/pyns/fetch_utils.py
@@ -20,7 +20,7 @@ except ImportError:
     install = None
     get = None
 
-def fetch_predictors(predictor_names, dataset_name, return_type='df', 
+def fetch_predictors(predictor_names, dataset_name, return_type='df', rescale=False,
     resample=True, api=None, **entities):
     """ Fetch predictors from Neuroscout API, and return as a 
     BIDSRunVariableCollection or pandas DataFrame
@@ -29,6 +29,7 @@ def fetch_predictors(predictor_names, dataset_name, return_type='df',
         predictor_names (str): Mame of predictors to fetch
         dataset_name (str): Name of dataset to fetch predictors from
         return_type (str): Either 'df' or 'BIDSRunVariableCollection'
+        rescale (bool): Whether to rescale predictors to mean 0, std 1
         resample (bool): Whether to resample predictors to TR
         api (pyns.Neuroscout): A instance of API (if None, will create one)
         entities (dict): Entities to filter by. e.g.: 'subject', 'session', 'run',
@@ -83,6 +84,10 @@ def fetch_predictors(predictor_names, dataset_name, return_type='df',
             predictor_names, df, run_info, 'events'))
             
     collection = BIDSRunVariableCollection(variables=variables)
+
+    if rescale:
+        from bids.modeling.transformations import Scale
+        Scale(collection, predictor_names)
 
     if resample:
         collection = collection.to_dense().resample('TR')


### PR DESCRIPTION
Adds a `fetch_utils` module, with the function `fetch_predictors` & `fetch_images`

This helper simplifies using `api.predictor_events` to fetch predictors.

After fetching predictors using `predictor_events`, it does the following:
- Grab `duration`, and `TR` from API for each unique run (from `/api/tasks`), and compute the probably `n_vols` for each. Note: ideally this would be grabbed directly from the volumes, rather than computed, but I didn't record this in the API. I could do this in the future, but need to add this to the API. 
- Creates a `BIDSVariableCollection` (pybids) from these Predictors, to facilitate resampling to `TR` (without reimplementing this logic). 
- Can return `BIDSVariableCollection` if the user wants to apply `Transformations` (e.g. scale), or can return a `df` (resampled or not). 

The main problem I see here is the `pybids` dependency, but I think this will help users grab TR resampled timeseries. 

`fetch_images` simplifies the process of fetching images from Neuroscout using datalad by:
- Given the name of a dataset and a path:
- Installing preproc dataset 
- Fetching files given a set of entities
- Uses pyBIDS to associate paths w/ entities (to match to events easily)